### PR TITLE
docs: rewrite README for Vite + React 19 stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,70 +1,70 @@
-# Getting Started with Create React App
+# Clara Toloba — Personal Website
 
-This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+Personal portfolio showcasing my work in **web development, photography and graphic design**.
 
-## Available Scripts
+🔗 Live: [claratoloba.com](https://claratoloba.com)
 
-In the project directory, you can run:
+## Tech stack
 
-### `npm start`
+- [React 19](https://react.dev/) — UI library
+- [Vite](https://vite.dev/) — build tool & dev server
+- [React Router](https://reactrouter.com/) — client-side routing
+- [MUI](https://mui.com/) — UI components
+- [Framer Motion](https://www.framer.com/motion/) & [AOS](https://michalsnik.github.io/aos/) — animations
+- [Lottie](https://airbnb.io/lottie/) — vector animations
+- [Sass](https://sass-lang.com/) — styling
+- TypeScript
 
-Runs the app in the development mode.\
-Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
+## Getting started
 
-The page will reload if you make edits.\
-You will also see any lint errors in the console.
+### Prerequisites
 
-### `npm test`
+- [Node.js](https://nodejs.org/) **22.x**
+- npm
 
-Launches the test runner in the interactive watch mode.\
-See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
+### Install
 
-### `npm run build`
+```bash
+npm install
+```
 
-Builds the app for production to the `build` folder.\
-It correctly bundles React in production mode and optimizes the build for the best performance.
+### Run locally
 
-The build is minified and the filenames include the hashes.\
-Your app is ready to be deployed!
+```bash
+npm run dev
+```
 
-See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
+Open [http://localhost:3000](http://localhost:3000) to view it in the browser. The page reloads automatically as you edit.
 
-### `npm run eject`
+## Available scripts
 
-**Note: this is a one-way operation. Once you `eject`, you can’t go back!**
+| Command | Description |
+| --- | --- |
+| `npm run dev` | Start the Vite dev server (with HMR) |
+| `npm run build` | Build for production into the `dist/` folder |
+| `npm run preview` | Preview the production build locally |
 
-If you aren’t satisfied with the build tool and configuration choices, you can `eject` at any time. This command will remove the single build dependency from your project.
+## Project structure
 
-Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you’re on your own.
+```
+public/            Static assets served as-is (favicon, icon fonts)
+src/
+  assets/          Images, fonts and Lottie animations
+  core/            Layout & routing (Header, Footer, Router)
+  pages/           Route pages (Home, About, Hero, WebDevelopment, Creative…)
+  shared/          Reusable components (Button, ProjectList, ProjectItem)
+  data/            Project/portfolio content (JSON)
+  styles/          Global Sass (settings, elements, blocks)
+  main.jsx         App entry point
+index.html         Vite HTML entry
+```
 
-You don’t have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn’t feel obligated to use this feature. However we understand that this tool wouldn’t be useful if you couldn’t customize it when you are ready for it.
+## Deployment
 
-## Learn More
+The site is deployed on [Netlify](https://www.netlify.com/). Configuration lives in [`netlify.toml`](./netlify.toml):
 
-You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
+- Build command: `npm run build`
+- Publish directory: `dist`
+- SPA fallback redirect so client-side routes (e.g. `/web`) resolve on reload
 
-To learn React, check out the [React documentation](https://reactjs.org/).
-
-### Code Splitting
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/code-splitting](https://facebook.github.io/create-react-app/docs/code-splitting)
-
-### Analyzing the Bundle Size
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/analyzing-the-bundle-size](https://facebook.github.io/create-react-app/docs/analyzing-the-bundle-size)
-
-### Making a Progressive Web App
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app](https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app)
-
-### Advanced Configuration
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/advanced-configuration](https://facebook.github.io/create-react-app/docs/advanced-configuration)
-
-### Deployment
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/deployment](https://facebook.github.io/create-react-app/docs/deployment)
-
-### `npm run build` fails to minify
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify](https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify)
+Every push to a pull request generates a Netlify deploy preview; merging to `main` deploys to production.


### PR DESCRIPTION
Replaces the stale Create React App boilerplate README (the project migrated to Vite + React 19 in #5) with project-specific docs:

- Tech stack overview
- Scripts: `dev` / `build` / `preview`
- Project structure
- Netlify deployment notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)